### PR TITLE
Add Qt-based project manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,40 +1,55 @@
 # NPMManager
 
-This project provides a simple Tkinter GUI for managing multiple NPM projects. It allows you to start servers on specific ports, update each project using `git pull origin main`, and view console output in one place.
+This application provides a PySide6 GUI for managing multiple NPM projects. Each
+project can be updated from git, launched on a specific port, and stopped from
+the interface. Configuration is stored in `projects.json`.
 
 ## Configuration
 
-Projects are defined in `projects.json` as a list of entries:
+Projects are listed in `projects.json` as follows:
 
 ```json
 {
   "projects": [
     {
       "name": "project1",
-      "path": "c:/code/project1",
-      "command": "npm start",
+      "path": "/path/to/project1",
+      "commands": ["npm start"],
       "port": 3000
     }
   ]
 }
 ```
 
-- `name` – display name for the project
-- `path` – path to the folder containing the project
-- `command` – command to start the server (for example `npm start` or `npm run dev`)
-- `port` – port number to set in the `PORT` environment variable when running the command
+- `name` – display name for the project.
+- `path` – folder containing the project.
+- `commands` – list of commands to launch the project. Each runs with the
+  `PORT` environment variable set.
+- `port` – port number to use when launching.
 
-Edit this file to match your projects.
+Edit this file or use the **Add Project** button in the GUI to manage your
+projects.
 
 ## Usage
 
-1. Install Python 3.x.
+1. Install Python 3.x and the `PySide6` package.
 2. Run the manager with:
 
 ```bash
 python3 manager.py
 ```
 
-The GUI shows each project with **Start**, **Stop**, and **Update** buttons. Clicking **Start** runs the project's command with `PORT` set to the specified value. **Update** runs `git pull origin main` in the project directory.
+The main window lists all configured projects. For each project you can:
 
-This application requires a graphical environment to display the Tkinter window.
+- **Update** – run `git pull origin main` in the project directory.
+- **Configure** – edit the commands used to launch the project.
+- **Set port** – change the port passed to `npm` via the `PORT` environment
+  variable.
+- **Launch** – run `npm install` followed by the configured commands.
+- **Stop** – terminate all running commands for that project.
+
+A log view at the bottom of the window displays progress output from all
+processes.
+
+This application requires a graphical environment capable of running Qt
+applications.

--- a/manager.py
+++ b/manager.py
@@ -1,72 +1,43 @@
 import os
+import sys
 import json
 import subprocess
-import tkinter as tk
-from tkinter import messagebox, scrolledtext
+import threading
+from typing import List
+
+from PySide6.QtWidgets import (
+    QApplication,
+    QMainWindow,
+    QWidget,
+    QVBoxLayout,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QFileDialog,
+    QInputDialog,
+    QPlainTextEdit,
+    QMessageBox,
+)
+from PySide6.QtCore import Qt
 
 
 class Project:
-    """Represent a single npm project and its running process."""
+    """Represent a single npm project and its running processes."""
 
-    def __init__(self, name, path, command, port):
+    def __init__(self, name: str, path: str, commands: List[str], port: int):
         self.name = name
         self.path = path
-        self.command = command
+        self.commands = commands
         self.port = port
-        self.process = None  # subprocess.Popen instance when running
+        self.processes: List[subprocess.Popen] = []
 
-    def start(self, log_fn):
-        """Start the project's npm command with PORT set."""
-        if self.process and self.process.poll() is None:
-            log_fn(f"{self.name} already running on port {self.port}\n")
-            return
+    def _log_prefix(self, msg: str) -> str:
+        """Prefix log messages with the project name."""
+        return f"[{self.name}] {msg}"
 
-        env = os.environ.copy()
-        env["PORT"] = str(self.port)
-        try:
-            # Start the command in a new process
-            self.process = subprocess.Popen(
-                self.command,
-                cwd=self.path,
-                env=env,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
-                shell=True,
-                text=True,
-            )
-            log_fn(f"Starting {self.name} on port {self.port}\n")
-        except FileNotFoundError:
-            log_fn(f"Failed to start {self.name}: command not found\n")
-            self.process = None
-            return
-
-        # Read initial output asynchronously
-        self._read_output_async(log_fn)
-
-    def _read_output_async(self, log_fn):
-        """Read one line from process output and schedule next read."""
-        if self.process is None:
-            return
-
-        line = self.process.stdout.readline()
-        if line:
-            log_fn(f"[{self.name}] {line}")
-        if self.process.poll() is None:
-            # Schedule next read
-            root.after(100, self._read_output_async, log_fn)
-        else:
-            log_fn(f"{self.name} stopped\n")
-
-    def stop(self, log_fn):
-        """Stop the running process if any."""
-        if self.process and self.process.poll() is None:
-            self.process.terminate()
-            log_fn(f"Stopping {self.name}\n")
-        else:
-            log_fn(f"{self.name} is not running\n")
-
-    def update(self, log_fn):
-        """Run 'git pull origin main' in the project directory."""
+    def update(self, log_fn) -> None:
+        """Run 'git pull origin main' for this project."""
+        log_fn(self._log_prefix("running git pull origin main"))
         try:
             result = subprocess.run(
                 ["git", "pull", "origin", "main"],
@@ -75,61 +46,229 @@ class Project:
                 stderr=subprocess.STDOUT,
                 text=True,
             )
-            log_fn(result.stdout + "\n")
+            log_fn(self._log_prefix(result.stdout))
             if result.returncode != 0:
-                messagebox.showerror(self.name, "Git pull failed")
+                QMessageBox.critical(None, self.name, "Git pull failed")
         except FileNotFoundError:
-            log_fn("Git not found. Is it installed?\n")
+            log_fn(self._log_prefix("git not found"))
+
+    def configure(self, commands: List[str], log_fn) -> None:
+        """Update the commands used to launch this project."""
+        self.commands = commands
+        log_fn(self._log_prefix("commands updated"))
+
+    def set_port(self, port: int, log_fn) -> None:
+        """Update the port for this project."""
+        self.port = port
+        log_fn(self._log_prefix(f"port set to {port}"))
+
+    def _read_output(self, process: subprocess.Popen, log_fn) -> None:
+        """Forward output from a subprocess to the log."""
+        for line in iter(process.stdout.readline, ""):
+            if line:
+                log_fn(self._log_prefix(line.rstrip()))
+        log_fn(self._log_prefix("process exited"))
+
+    def launch(self, log_fn) -> None:
+        """Run 'npm install' then start project commands concurrently."""
+        env = os.environ.copy()
+        env["PORT"] = str(self.port)
+        log_fn(self._log_prefix("running npm install"))
+        subprocess.run(["npm", "install"], cwd=self.path, env=env)
+
+        for cmd in self.commands:
+            process = subprocess.Popen(
+                cmd,
+                cwd=self.path,
+                env=env,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                shell=True,
+                text=True,
+            )
+            self.processes.append(process)
+            thread = threading.Thread(
+                target=self._read_output, args=(process, log_fn), daemon=True
+            )
+            thread.start()
+        log_fn(self._log_prefix("launched"))
+
+    def stop(self, log_fn) -> None:
+        """Terminate all running processes for this project."""
+        for proc in self.processes:
+            if proc.poll() is None:
+                proc.terminate()
+        self.processes.clear()
+        log_fn(self._log_prefix("stopped"))
 
 
-def load_projects(cfg_path):
+def load_projects(cfg_path: str) -> List[Project]:
     """Load project definitions from a JSON configuration file."""
     with open(cfg_path) as f:
         data = json.load(f)
 
     projects = []
     for entry in data.get("projects", []):
+        commands = entry.get("commands") or [entry.get("command", "npm start")]
         projects.append(
             Project(
-                entry.get("name"),
-                entry.get("path"),
-                entry.get("command", "npm start"),
+                entry.get("name", "unnamed"),
+                entry.get("path", "."),
+                commands,
                 entry.get("port", 3000),
             )
         )
     return projects
 
 
-def build_gui(projects):
-    """Create the tkinter UI for managing projects."""
-    global root
-    root = tk.Tk()
-    root.title("NPM Project Manager")
-
-    log_box = scrolledtext.ScrolledText(root, width=80, height=20)
-    log_box.grid(row=len(projects) + 1, column=0, columnspan=4, padx=5, pady=5)
-
-    def log(message):
-        log_box.insert(tk.END, message)
-        log_box.see(tk.END)
-
-    for idx, proj in enumerate(projects):
-        tk.Label(root, text=proj.name).grid(row=idx, column=0, padx=5, pady=5, sticky="w")
-        tk.Label(root, text=f"Port: {proj.port}").grid(row=idx, column=1, padx=5, pady=5)
-
-        tk.Button(root, text="Start", command=lambda p=proj: p.start(log)).grid(row=idx, column=2)
-        tk.Button(root, text="Stop", command=lambda p=proj: p.stop(log)).grid(row=idx, column=3)
-        tk.Button(root, text="Update", command=lambda p=proj: p.update(log)).grid(row=idx, column=4)
-
-    return root
+def save_projects(cfg_path: str, projects: List[Project]) -> None:
+    """Write current project configuration back to JSON."""
+    data = {
+        "projects": [
+            {
+                "name": p.name,
+                "path": p.path,
+                "commands": p.commands,
+                "port": p.port,
+            }
+            for p in projects
+        ]
+    }
+    with open(cfg_path, "w") as f:
+        json.dump(data, f, indent=2)
 
 
+class MainWindow(QMainWindow):
+    """Qt window for managing multiple npm projects."""
+
+    def __init__(self, projects: List[Project], cfg_path: str) -> None:
+        super().__init__()
+        self.projects = projects
+        self.cfg_path = cfg_path
+        self.setWindowTitle("NPM Project Manager")
+        self._build_ui()
+
+    # UI construction -----------------------------------------------------
+    def _build_ui(self) -> None:
+        central = QWidget()
+        self.setCentralWidget(central)
+        self.vbox = QVBoxLayout()
+        central.setLayout(self.vbox)
+
+        # Add UI rows for each project
+        for project in self.projects:
+            self._add_project_row(project)
+
+        add_btn = QPushButton("Add Project")
+        add_btn.clicked.connect(self._add_project_dialog)
+        self.vbox.addWidget(add_btn)
+
+        self.log_widget = QPlainTextEdit()
+        self.log_widget.setReadOnly(True)
+        self.vbox.addWidget(self.log_widget)
+
+    def _add_project_row(self, project: Project) -> None:
+        """Create UI elements for a single project."""
+        row = QHBoxLayout()
+
+        name_label = QLabel(project.name)
+        port_label = QLabel(f"Port: {project.port}")
+
+        update_btn = QPushButton("Update")
+        update_btn.clicked.connect(lambda: project.update(self._log))
+
+        config_btn = QPushButton("Configure")
+        config_btn.clicked.connect(lambda: self._configure_project(project))
+
+        port_btn = QPushButton("Set port")
+        port_btn.clicked.connect(lambda: self._set_port(project, port_label))
+
+        launch_btn = QPushButton("Launch")
+        launch_btn.clicked.connect(lambda: project.launch(self._log))
+
+        stop_btn = QPushButton("Stop")
+        stop_btn.clicked.connect(lambda: project.stop(self._log))
+
+        for widget in [name_label, port_label, update_btn, config_btn, port_btn, launch_btn, stop_btn]:
+            row.addWidget(widget)
+
+        container = QWidget()
+        container.setLayout(row)
+        self.vbox.addWidget(container)
+
+    def _log(self, message: str) -> None:
+        """Append a message to the log window."""
+        self.log_widget.appendPlainText(message)
+        self.log_widget.ensureCursorVisible()
+
+    # Dialog helpers ------------------------------------------------------
+    def _add_project_dialog(self) -> None:
+        """Prompt the user for new project information and add it."""
+        path = QFileDialog.getExistingDirectory(self, "Select Project Folder")
+        if not path:
+            return
+        name, ok = QInputDialog.getText(self, "Project Name", "Name:")
+        if not ok or not name:
+            return
+        cmd_text, ok = QInputDialog.getMultiLineText(
+            self,
+            "Commands",
+            "Enter commands (one per line):",
+            "npm start",
+        )
+        if not ok:
+            return
+        port, ok = QInputDialog.getInt(self, "Port", "Port:", 3000, 1, 65535)
+        if not ok:
+            return
+
+        commands = [c.strip() for c in cmd_text.splitlines() if c.strip()]
+        project = Project(name, path, commands, port)
+        self.projects.append(project)
+        self._add_project_row(project)
+        save_projects(self.cfg_path, self.projects)
+
+    def _configure_project(self, project: Project) -> None:
+        """Edit the commands for an existing project."""
+        current = "\n".join(project.commands)
+        cmd_text, ok = QInputDialog.getMultiLineText(
+            self,
+            "Configure Commands",
+            "Commands (one per line):",
+            current,
+        )
+        if ok:
+            commands = [c.strip() for c in cmd_text.splitlines() if c.strip()]
+            project.configure(commands, self._log)
+            save_projects(self.cfg_path, self.projects)
+
+    def _set_port(self, project: Project, label: QLabel) -> None:
+        """Prompt for a new port and update the project."""
+        port, ok = QInputDialog.getInt(
+            self, "Set Port", "Port:", project.port, 1, 65535
+        )
+        if ok:
+            project.set_port(port, self._log)
+            label.setText(f"Port: {project.port}")
+            save_projects(self.cfg_path, self.projects)
+
+
+# Application entry point -------------------------------------------------
 if __name__ == "__main__":
-    config_file = os.path.join(os.path.dirname(__file__), "projects.json")
-    if not os.path.exists(config_file):
-        messagebox.showerror("Error", f"Configuration file {config_file} not found")
-        raise SystemExit
+    app = QApplication(sys.argv)
+    cfg_file = os.path.join(os.path.dirname(__file__), "projects.json")
+    if not os.path.exists(cfg_file):
+        QMessageBox.critical(None, "Error", f"Configuration file {cfg_file} not found")
+        sys.exit(1)
 
-    projs = load_projects(config_file)
-    gui = build_gui(projs)
-    gui.mainloop()
+    projects = load_projects(cfg_file)
+    window = MainWindow(projects, cfg_file)
+
+    # Ensure all processes stop when the application closes
+    def _cleanup() -> None:
+        for p in projects:
+            p.stop(lambda msg: None)
+
+    app.aboutToQuit.connect(_cleanup)
+    window.show()
+    sys.exit(app.exec())

--- a/projects.json
+++ b/projects.json
@@ -2,14 +2,14 @@
   "projects": [
     {
       "name": "project1",
-      "path": "c:/code/project1",
-      "command": "npm start",
+      "path": "/path/to/project1",
+      "commands": ["npm start"],
       "port": 3000
     },
     {
       "name": "project2",
-      "path": "c:/code/project2",
-      "command": "npm run dev",
+      "path": "/path/to/project2",
+      "commands": ["npm run dev"],
       "port": 5000
     }
   ]


### PR DESCRIPTION
## Summary
- switch from Tkinter to PySide6 for the GUI
- allow adding new projects via a dialog
- support editing commands and ports for projects
- launch runs `npm install` and multiple commands concurrently
- update example configuration and README

## Testing
- `python3 -m py_compile manager.py`


------
https://chatgpt.com/codex/tasks/task_e_68645bbbf7c08328b93dde561922428a