### PR TITLE
Add CLI fallback for manager

### DIFF
--- a/manager.py
+++ b/manager.py
@@ -5,20 +5,36 @@ import subprocess
 import threading
 from typing import List
 
-from PySide6.QtWidgets import (
-    QApplication,
-    QMainWindow,
-    QWidget,
-    QVBoxLayout,
-    QHBoxLayout,
-    QLabel,
-    QPushButton,
-    QFileDialog,
-    QInputDialog,
-    QPlainTextEdit,
-    QMessageBox,
-)
-from PySide6.QtCore import Qt
+"""Simple NPM project manager.
+
+This script originally provided a PySide6 GUI for managing NPM projects.  To
+allow running it directly from a regular command prompt without any GUI
+dependencies installed, it now falls back to a command line interface when
+PySide6 is not available or the ``--cli`` flag is supplied.  The GUI code is
+still present and used when possible.
+"""
+
+import argparse
+
+try:
+    from PySide6.QtWidgets import (
+        QApplication,
+        QMainWindow,
+        QWidget,
+        QVBoxLayout,
+        QHBoxLayout,
+        QLabel,
+        QPushButton,
+        QFileDialog,
+        QInputDialog,
+        QPlainTextEdit,
+        QMessageBox,
+    )
+    from PySide6.QtCore import Qt
+    HAS_QT = True
+except ModuleNotFoundError:
+    # Qt is optional when running in CLI mode
+    HAS_QT = False
 
 
 class Project:
@@ -138,130 +154,231 @@ def save_projects(cfg_path: str, projects: List[Project]) -> None:
         json.dump(data, f, indent=2)
 
 
-class MainWindow(QMainWindow):
-    """Qt window for managing multiple npm projects."""
+def run_cli(projects: List[Project], cfg_path: str) -> None:
+    """Command line interface for managing projects.
 
-    def __init__(self, projects: List[Project], cfg_path: str) -> None:
-        super().__init__()
-        self.projects = projects
-        self.cfg_path = cfg_path
-        self.setWindowTitle("NPM Project Manager")
-        self._build_ui()
+    This mode provides a handful of sub-commands roughly matching the GUI
+    functionality.  It allows updating projects from git, launching commands and
+    modifying the configuration directly from a terminal window.
+    """
+    parser = argparse.ArgumentParser(description="NPM project manager (CLI)")
+    sub = parser.add_subparsers(dest="cmd", required=True)
 
-    # UI construction -----------------------------------------------------
-    def _build_ui(self) -> None:
-        central = QWidget()
-        self.setCentralWidget(central)
-        self.vbox = QVBoxLayout()
-        central.setLayout(self.vbox)
+    sub.add_parser("list", help="List configured projects")
 
-        # Add UI rows for each project
-        for project in self.projects:
-            self._add_project_row(project)
+    add = sub.add_parser("add", help="Add a new project")
+    add.add_argument("name")
+    add.add_argument("path")
+    add.add_argument("--command", action="append", dest="commands",
+                    help="Command to launch (can be repeated)")
+    add.add_argument("--port", type=int, default=3000)
 
-        add_btn = QPushButton("Add Project")
-        add_btn.clicked.connect(self._add_project_dialog)
-        self.vbox.addWidget(add_btn)
+    upd = sub.add_parser("update", help="Run 'git pull' for a project")
+    upd.add_argument("name")
 
-        self.log_widget = QPlainTextEdit()
-        self.log_widget.setReadOnly(True)
-        self.vbox.addWidget(self.log_widget)
+    lan = sub.add_parser("launch", help="Run 'npm install' and start commands")
+    lan.add_argument("name")
 
-    def _add_project_row(self, project: Project) -> None:
-        """Create UI elements for a single project."""
-        row = QHBoxLayout()
+    setp = sub.add_parser("set-port", help="Change port for a project")
+    setp.add_argument("name")
+    setp.add_argument("port", type=int)
 
-        name_label = QLabel(project.name)
-        port_label = QLabel(f"Port: {project.port}")
+    cfg = sub.add_parser("configure", help="Replace launch commands")
+    cfg.add_argument("name")
+    cfg.add_argument("commands", nargs="+",
+                     help="Commands to run (space separated)")
 
-        update_btn = QPushButton("Update")
-        update_btn.clicked.connect(lambda: project.update(self._log))
+    args = parser.parse_args()
 
-        config_btn = QPushButton("Configure")
-        config_btn.clicked.connect(lambda: self._configure_project(project))
+    # Map project names for easy lookup
+    name_map = {p.name: p for p in projects}
 
-        port_btn = QPushButton("Set port")
-        port_btn.clicked.connect(lambda: self._set_port(project, port_label))
+    def require_project(name: str) -> Project:
+        if name not in name_map:
+            parser.error(f"Unknown project: {name}")
+        return name_map[name]
 
-        launch_btn = QPushButton("Launch")
-        launch_btn.clicked.connect(lambda: project.launch(self._log))
+    if args.cmd == "list":
+        for p in projects:
+            print(f"{p.name} - {p.path} (port {p.port}) -> {p.commands}")
+        return
 
-        stop_btn = QPushButton("Stop")
-        stop_btn.clicked.connect(lambda: project.stop(self._log))
+    if args.cmd == "add":
+        commands = args.commands or ["npm start"]
+        proj = Project(args.name, args.path, commands, args.port)
+        projects.append(proj)
+        save_projects(cfg_path, projects)
+        print(f"Added project {args.name}")
+        return
 
-        for widget in [name_label, port_label, update_btn, config_btn, port_btn, launch_btn, stop_btn]:
-            row.addWidget(widget)
+    project = require_project(args.name)
 
-        container = QWidget()
-        container.setLayout(row)
-        self.vbox.addWidget(container)
+    if args.cmd == "update":
+        project.update(print)
+        return
 
-    def _log(self, message: str) -> None:
-        """Append a message to the log window."""
-        self.log_widget.appendPlainText(message)
-        self.log_widget.ensureCursorVisible()
+    if args.cmd == "launch":
+        project.launch(print)
+        try:
+            # Wait for all launched commands to finish so that output remains
+            # visible in the terminal.  Ctrl+C can be used to interrupt.
+            for proc in project.processes:
+                proc.wait()
+        except KeyboardInterrupt:
+            pass
+        finally:
+            project.stop(print)
+        return
 
-    # Dialog helpers ------------------------------------------------------
-    def _add_project_dialog(self) -> None:
-        """Prompt the user for new project information and add it."""
-        path = QFileDialog.getExistingDirectory(self, "Select Project Folder")
-        if not path:
-            return
-        name, ok = QInputDialog.getText(self, "Project Name", "Name:")
-        if not ok or not name:
-            return
-        cmd_text, ok = QInputDialog.getMultiLineText(
-            self,
-            "Commands",
-            "Enter commands (one per line):",
-            "npm start",
-        )
-        if not ok:
-            return
-        port, ok = QInputDialog.getInt(self, "Port", "Port:", 3000, 1, 65535)
-        if not ok:
-            return
+    if args.cmd == "set-port":
+        project.set_port(args.port, print)
+        save_projects(cfg_path, projects)
+        return
 
-        commands = [c.strip() for c in cmd_text.splitlines() if c.strip()]
-        project = Project(name, path, commands, port)
-        self.projects.append(project)
-        self._add_project_row(project)
-        save_projects(self.cfg_path, self.projects)
+    if args.cmd == "configure":
+        project.configure(args.commands, print)
+        save_projects(cfg_path, projects)
+        return
 
-    def _configure_project(self, project: Project) -> None:
-        """Edit the commands for an existing project."""
-        current = "\n".join(project.commands)
-        cmd_text, ok = QInputDialog.getMultiLineText(
-            self,
-            "Configure Commands",
-            "Commands (one per line):",
-            current,
-        )
-        if ok:
+
+if HAS_QT:
+    class MainWindow(QMainWindow):
+        """Qt window for managing multiple npm projects."""
+
+        def __init__(self, projects: List[Project], cfg_path: str) -> None:
+            super().__init__()
+            self.projects = projects
+            self.cfg_path = cfg_path
+            self.setWindowTitle("NPM Project Manager")
+            self._build_ui()
+
+        # UI construction -----------------------------------------------------
+        def _build_ui(self) -> None:
+            central = QWidget()
+            self.setCentralWidget(central)
+            self.vbox = QVBoxLayout()
+            central.setLayout(self.vbox)
+    
+            # Add UI rows for each project
+            for project in self.projects:
+                self._add_project_row(project)
+    
+            add_btn = QPushButton("Add Project")
+            add_btn.clicked.connect(self._add_project_dialog)
+            self.vbox.addWidget(add_btn)
+    
+            self.log_widget = QPlainTextEdit()
+            self.log_widget.setReadOnly(True)
+            self.vbox.addWidget(self.log_widget)
+    
+        def _add_project_row(self, project: Project) -> None:
+            """Create UI elements for a single project."""
+            row = QHBoxLayout()
+    
+            name_label = QLabel(project.name)
+            port_label = QLabel(f"Port: {project.port}")
+    
+            update_btn = QPushButton("Update")
+            update_btn.clicked.connect(lambda: project.update(self._log))
+    
+            config_btn = QPushButton("Configure")
+            config_btn.clicked.connect(lambda: self._configure_project(project))
+    
+            port_btn = QPushButton("Set port")
+            port_btn.clicked.connect(lambda: self._set_port(project, port_label))
+    
+            launch_btn = QPushButton("Launch")
+            launch_btn.clicked.connect(lambda: project.launch(self._log))
+    
+            stop_btn = QPushButton("Stop")
+            stop_btn.clicked.connect(lambda: project.stop(self._log))
+    
+            for widget in [name_label, port_label, update_btn, config_btn, port_btn, launch_btn, stop_btn]:
+                row.addWidget(widget)
+    
+            container = QWidget()
+            container.setLayout(row)
+            self.vbox.addWidget(container)
+    
+        def _log(self, message: str) -> None:
+            """Append a message to the log window."""
+            self.log_widget.appendPlainText(message)
+            self.log_widget.ensureCursorVisible()
+    
+        # Dialog helpers ------------------------------------------------------
+        def _add_project_dialog(self) -> None:
+            """Prompt the user for new project information and add it."""
+            path = QFileDialog.getExistingDirectory(self, "Select Project Folder")
+            if not path:
+                return
+            name, ok = QInputDialog.getText(self, "Project Name", "Name:")
+            if not ok or not name:
+                return
+            cmd_text, ok = QInputDialog.getMultiLineText(
+                self,
+                "Commands",
+                "Enter commands (one per line):",
+                "npm start",
+            )
+            if not ok:
+                return
+            port, ok = QInputDialog.getInt(self, "Port", "Port:", 3000, 1, 65535)
+            if not ok:
+                return
+    
             commands = [c.strip() for c in cmd_text.splitlines() if c.strip()]
-            project.configure(commands, self._log)
+            project = Project(name, path, commands, port)
+            self.projects.append(project)
+            self._add_project_row(project)
             save_projects(self.cfg_path, self.projects)
-
-    def _set_port(self, project: Project, label: QLabel) -> None:
-        """Prompt for a new port and update the project."""
-        port, ok = QInputDialog.getInt(
-            self, "Set Port", "Port:", project.port, 1, 65535
-        )
-        if ok:
-            project.set_port(port, self._log)
-            label.setText(f"Port: {project.port}")
-            save_projects(self.cfg_path, self.projects)
+    
+        def _configure_project(self, project: Project) -> None:
+            """Edit the commands for an existing project."""
+            current = "\n".join(project.commands)
+            cmd_text, ok = QInputDialog.getMultiLineText(
+                self,
+                "Configure Commands",
+                "Commands (one per line):",
+                current,
+            )
+            if ok:
+                commands = [c.strip() for c in cmd_text.splitlines() if c.strip()]
+                project.configure(commands, self._log)
+                save_projects(self.cfg_path, self.projects)
+    
+        def _set_port(self, project: Project, label: QLabel) -> None:
+            """Prompt for a new port and update the project."""
+            port, ok = QInputDialog.getInt(
+                self, "Set Port", "Port:", project.port, 1, 65535
+            )
+            if ok:
+                project.set_port(port, self._log)
+                label.setText(f"Port: {project.port}")
+                save_projects(self.cfg_path, self.projects)
 
 
 # Application entry point -------------------------------------------------
 if __name__ == "__main__":
-    app = QApplication(sys.argv)
     cfg_file = os.path.join(os.path.dirname(__file__), "projects.json")
     if not os.path.exists(cfg_file):
-        QMessageBox.critical(None, "Error", f"Configuration file {cfg_file} not found")
+        msg = f"Configuration file {cfg_file} not found"
+        if HAS_QT:
+            QMessageBox.critical(None, "Error", msg)
+        else:
+            print(msg)
         sys.exit(1)
 
     projects = load_projects(cfg_file)
+
+    # Use CLI when Qt isn't available or the --cli flag was supplied
+    if not HAS_QT or "--cli" in sys.argv:
+        if "--cli" in sys.argv:
+            sys.argv.remove("--cli")
+        run_cli(projects, cfg_file)
+        sys.exit(0)
+
+    # GUI mode -----------------------------------------------------------
+    app = QApplication(sys.argv)
     window = MainWindow(projects, cfg_file)
 
     # Ensure all processes stop when the application closes


### PR DESCRIPTION
## Summary
- add optional command line interface when PySide6 isn't installed
- refactor GUI imports and guard Qt components
- implement CLI subcommands for listing, updating, launching, configuring
- use CLI automatically on systems without PySide6

## Testing
- `python3 -m py_compile manager.py`
- `python3 manager.py --cli list`

------
https://chatgpt.com/codex/tasks/task_e_68645fe324e883288af18dc1600f2672