### PR TITLE
Add stop and rename buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,13 @@ Projects are stored in `projects.json`:
 ```json
 {
   "projects": [
-    { "path": "/path/to/app", "port": 3000 }
+    { "path": "/path/to/app", "port": 3000, "name": "my-app" }
   ]
 }
 ```
 
-Each entry defines the folder containing the Node.js project and the port to use when starting it.
+Each entry defines the folder containing the Node.js project, the port to use
+when starting it and an optional custom PM2 process name.
 
 ## Setup
 
@@ -42,6 +43,8 @@ For every configured project you can:
 
 - **Update** – run `git pull origin main` inside the project directory.
 - **Run** – start the project with `pm2` using `npm start` and the selected port.
+- **Stop** – stop the running PM2 process.
+- **Change Name** – set a custom name for the PM2 process.
 
 New projects can be added using the **Add Project** button.
 

--- a/projects.json
+++ b/projects.json
@@ -2,11 +2,13 @@
   "projects": [
     {
       "path": "/path/to/project1",
-      "port": 3000
+      "port": 3000,
+      "name": "project1"
     },
     {
       "path": "/path/to/project2",
-      "port": 5000
+      "port": 5000,
+      "name": "project2"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- add optional `name` field in project config
- persist custom name in `projects.json`
- add Stop and Change Name buttons for each project
- update README with new instructions

## Testing
- `python -m py_compile manager.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_687cb7c78b3c832890dfa3453eeb58e9