### PR TITLE
Improve error messages for missing commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ PM2 must also be installed globally:
 ```bash
 npm install -g pm2
 ```
+If `pm2` isn't found after installation, ensure that the global npm binaries
+directory (for example `%APPDATA%\npm` on Windows) is included in your `PATH`
+environment variable and restart the terminal.
 
 ## Usage
 


### PR DESCRIPTION
## Summary
- add FileNotFoundError handling so the GUI reports missing `git` or `pm2`
- document that `pm2` must be on PATH after installation

## Testing
- `python3 -m pip install -r requirements.txt`
- `python3 -m py_compile manager.py`

------
https://chatgpt.com/codex/tasks/task_e_687cc0e8f0c48328aa5ea548db584dea