### PR TITLE
Improve pm2 checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ npm install -g pm2
 If `pm2` isn't found after installation, ensure that the global npm binaries
 directory (for example `%APPDATA%\npm` on Windows) is included in your `PATH`
 environment variable and restart the terminal.
+The application checks for `pm2` on startup and before running or stopping
+projects. If it is missing you will see a clear error message explaining how to
+install it.
 
 ## Usage
 


### PR DESCRIPTION
## Summary
- check availability of `pm2` and `npm` before running projects
- warn user at startup if `pm2` is missing
- document pm2 checks in README

## Testing
- `python -m pip install -r requirements.txt`
- `python -m py_compile manager.py`


------
https://chatgpt.com/codex/tasks/task_e_687cc7c55588832893cb80573ade9f15